### PR TITLE
Improved: estimated ShipDate and deliveryDate format, loader on refreshing, UI of group header on transfers page (#1)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onBeforeMount, onMounted, onUnmounted, ref } from "vue";
 import { IonApp, IonRouterOutlet, loadingController } from "@ionic/vue";
 import emitter from "@/event-bus"
 import { Settings } from 'luxon'
@@ -65,16 +65,12 @@ function dismissLoader() {
   }
 }
 
-onMounted(async () => {
-  loader.value = await loadingController
-    .create({
-      message: translate("Click the backdrop to dismiss."),
-      translucent: true,
-      backdropDismiss: true
-    });
-  emitter.on("presentLoader", presentLoader);
-  emitter.on("dismissLoader", dismissLoader);
+onBeforeMount(() => {
+  emitter.on('presentLoader', presentLoader);
+  emitter.on('dismissLoader', dismissLoader);
+})
 
+onMounted(async () => {
   if (userProfile.value) {
     // Luxon timezone should be set with the user's selected timezone
     userProfile.value.timeZone && (Settings.defaultZone = userProfile.value.timeZone);

--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -99,7 +99,7 @@
         <ion-modal class="date-time-modal" :is-open="dateTimeModalOpen" @didDismiss="closeDateTimeModal">
           <ion-content force-overscroll="false">
             <ion-datetime 
-              :value="currentOrder[selectedDateFilter]"
+              :value="currentOrder[selectedDateFilter] ? currentOrder[selectedDateFilter] : DateTime.now().toISO()"
               show-clear-button
               show-default-buttons
               presentation="date"
@@ -515,8 +515,8 @@ async function createOrder() {
       orderFacilityId: currentOrder.value.destinationFacilityId,
       carrierPartyId: currentOrder.value.carrierPartyId,
       shipmentMethodTypeId: currentOrder.value.shipmentMethodTypeId,
-      estimatedShipDate: currentOrder.value.shipDate ? DateTime.fromISO(currentOrder.value.shipDate).toMillis() : "",
-      estimatedDeliveryDate: currentOrder.value.deliveryDate ? DateTime.fromISO(currentOrder.value.deliveryDate).toMillis() : "",
+      estimatedShipDate: currentOrder.value.shipDate ? DateTime.fromISO(currentOrder.value.shipDate).toFormat("yyyy-mm-dd 23:59:59.000") : "",
+      estimatedDeliveryDate: currentOrder.value.deliveryDate ? DateTime.fromISO(currentOrder.value.deliveryDate).toFormat("yyyy-mm-dd 23:59:59.000") : "",
       items: currentOrder.value.items.map((item: any) => {
         return {
           productId: item.productId,

--- a/src/views/Transfers.vue
+++ b/src/views/Transfers.vue
@@ -174,7 +174,7 @@
                       <ion-item lines="none">
                         <ion-icon slot="start" :icon="query.groupBy === 'facilityName' ? sendOutline : downloadOutline" />
                         <ion-label>
-                          <strong>{{ order.groupValue }}</strong>
+                          {{ order.groupValue }}
                           <p>{{ query.groupBy === 'facilityName' ? order.originFacilityId : order.destinationFacilityId }}</p>
                         </ion-label>
                       </ion-item>
@@ -244,7 +244,7 @@
                           <Image :src="getProduct(order.productId)?.mainImageUrl" />
                         </ion-thumbnail>
                         <ion-label>
-                          <strong>{{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.primaryId, getProduct(order.productId)) || getProduct(order.productId).productName }}</strong>
+                          {{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.primaryId, getProduct(order.productId)) || getProduct(order.productId).productName }}
                           <p>{{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.secondaryId, getProduct(order.productId)) }}</p>
                         </ion-label>
                       </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Sending estimated deliver and ship date in desired format.
- Auto select today's date on date time modal.
- Fixed loader not showing up on refreshing app.
- Removed bold from section header of grouping list in transfers page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)