### PR TITLE
Improved: selecting current ecomStore by default in the createOrder page (#16)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -276,7 +276,7 @@ watch(queryString, (value) => {
 onIonViewDidEnter(async () => {
   emitter.emit("presentLoader")
   stores.value = useUserStore().eComStores
-  if(stores.value?.length) currentOrder.value.productStoreId = stores.value[0]?.productStoreId
+  currentOrder.value.productStoreId = useUserStore().getCurrentEComStore?.productStoreId
   await Promise.allSettled([fetchFacilitiesByCurrentStore(), store.dispatch("util/fetchStoreCarrierAndMethods", currentOrder.value.productStoreId), store.dispatch("util/fetchCarriersDetail"), await store.dispatch('util/fetchStatusDesc')])
   if(Object.keys(shipmentMethodsByCarrier.value)?.length) {
     currentOrder.value.carrierPartyId = Object.keys(shipmentMethodsByCarrier.value)[0]


### PR DESCRIPTION
 Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#16

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
By default setting the current product store in the product store selector in create order page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)