### PR TITLE
Fixed: products list getting empty on infinite scrolling and allow add order item in created status only (#19)

### DIFF
--- a/src/components/AddProductModal.vue
+++ b/src/components/AddProductModal.vue
@@ -27,7 +27,7 @@
         </ion-item>
       </ion-list>
 
-      <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable">
+      <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable()">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
     </template>
@@ -120,8 +120,6 @@ async function getProducts( vSize?: any, vIndex?: any) {
     }
   } catch(error) {
     logger.error(error)
-    products.value = []
-    total.value = 0
   }
 }
 

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -158,7 +158,7 @@
               <h1>{{ translate("Items") }}</h1>
               <p>{{ translate(selectedShipmentId ? "Showing items for selected shipment" : "Showing all order items") }}</p>
             </ion-label>
-            <ion-button size="default" fill="outline" color="medium" v-if="!selectedShipmentId" :disabled="isOrderFinished()" @click="addProduct()">
+            <ion-button size="default" fill="outline" color="medium" v-if="!selectedShipmentId" :disabled="currentOrder.statusId !== 'ORDER_CREATED'" @click="addProduct()">
               {{ translate("Add item to transfer") }}
             </ion-button>
           </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#19

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed issue in add item modal related to no product on infinite scrolling.
- Added check to allow user to add order item only in case of order with "CREATED" status.
  
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)