### PR TITLE
Fixed: negative quantity getting set on edit ordered quantity of item (#22)

### DIFF
--- a/src/components/OrderItemDetailActionsPopover.vue
+++ b/src/components/OrderItemDetailActionsPopover.vue
@@ -46,9 +46,9 @@ async function editOrderedQuantity() {
       text: translate("Save"),
       handler: async (data: any) => {
         const quantity = Number(data.quantity);
-        if(!quantity) {
+        if(!quantity || quantity < 0) {
           showToast(translate("Please enter a valid quantity."))
-          return;
+          return false;
         }
         if(quantity !== props.item.quantity) {
           try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#22

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now allowing user to save -ve value as item ordered quantity.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)