### PR TITLE
Improved: logic to fetch the orders filter facets seperately (#49)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -101,7 +101,7 @@ const actions: ActionTree<OrderState, RootState> = {
   },
   
   async fetchOrderFilters({ commit, state }) {
-    const query = prepareOrderQuery({ ...(state.query), fetchFacets: true })
+    const query = prepareOrderQuery({ ...(state.query), fetchFacets: true, viewSize: 0 })
 
     try {
       const resp = await OrderService.findOrder(query);

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -57,24 +57,6 @@ const actions: ActionTree<OrderState, RootState> = {
 
         productIds = [...productIds]
 
-        // Added check as we are fetching the facets only on first request call and do not fetch facets information on infinite scroll
-        if(params?.fetchFacets) {
-          const originFacilities = resp.data.facets?.facilityNameFacet?.buckets.map((bucket: any) => bucket.val)
-          const destinationFacilities = resp.data.facets?.orderFacilityNameFacet?.buckets.map((bucket: any) => bucket.val)
-          const productStores = resp.data.facets?.productStoreIdFacet?.buckets.map((bucket: any) => bucket.val)
-          const carriers = resp.data.facets?.carrierPartyIdFacet?.buckets.map((bucket: any) => bucket.val)
-          const shipmentMethodTypeIds = resp.data.facets?.shipmentMethodTypeIdFacet?.buckets.map((bucket: any) => bucket.val)
-          const statuses = resp.data.facets?.orderStatusDescFacet?.buckets.map((bucket: any) => bucket.val)
-
-          commit(types.ORDER_PRODUCT_STORE_OPTIONS_UPDATED, productStores);
-          commit(types.ORDER_ORIGIN_FACILITY_OPTIONS_UPDATED, originFacilities);
-          commit(types.ORDER_DESTINATION_FACILITY_OPTIONS_UPDATED, destinationFacilities);
-          commit(types.ORDER_CARRIERS_OPTIONS_UPDATED, carriers);
-          commit(types.ORDER_SHIPMENT_METHODS_OPTIONS_UPDATED, shipmentMethodTypeIds);
-          commit(types.ORDER_STATUS_OPTIONS_UPDATED, statuses);
-        }
-
-
         const orderItemStats = await OrderService.fetchOrderItemStats(orderItemsList);
         orders.map((order: any) => {
           let totalOrdered = 0, totalShipped = 0, totalReceived = 0;
@@ -118,6 +100,34 @@ const actions: ActionTree<OrderState, RootState> = {
     return resp;
   },
   
+  async fetchOrderFilters({ commit, state }) {
+    const query = prepareOrderQuery({ ...(state.query), fetchFacets: true })
+
+    try {
+      const resp = await OrderService.findOrder(query);
+
+      if(!hasError(resp)) {
+        const originFacilities = resp.data.facets?.facilityNameFacet?.buckets.map((bucket: any) => bucket.val)
+        const destinationFacilities = resp.data.facets?.orderFacilityNameFacet?.buckets.map((bucket: any) => bucket.val)
+        const productStores = resp.data.facets?.productStoreIdFacet?.buckets.map((bucket: any) => bucket.val)
+        const carriers = resp.data.facets?.carrierPartyIdFacet?.buckets.map((bucket: any) => bucket.val)
+        const shipmentMethodTypeIds = resp.data.facets?.shipmentMethodTypeIdFacet?.buckets.map((bucket: any) => bucket.val)
+        const statuses = resp.data.facets?.orderStatusDescFacet?.buckets.map((bucket: any) => bucket.val)
+
+        commit(types.ORDER_PRODUCT_STORE_OPTIONS_UPDATED, productStores);
+        commit(types.ORDER_ORIGIN_FACILITY_OPTIONS_UPDATED, originFacilities);
+        commit(types.ORDER_DESTINATION_FACILITY_OPTIONS_UPDATED, destinationFacilities);
+        commit(types.ORDER_CARRIERS_OPTIONS_UPDATED, carriers);
+        commit(types.ORDER_SHIPMENT_METHODS_OPTIONS_UPDATED, shipmentMethodTypeIds);
+        commit(types.ORDER_STATUS_OPTIONS_UPDATED, statuses);
+      } else {
+        throw resp.data;
+      }
+    } catch(error: any) {
+      logger.error(error)
+    }
+  },
+
   async updateAppliedFilters({ commit, dispatch }, payload) {
     commit(types.ORDER_FILTERS_UPDATED, payload)
     await dispatch("findOrders", { isFilterUpdated: true })

--- a/src/utils/solrHelper.ts
+++ b/src/utils/solrHelper.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 const prepareOrderQuery = (query: any) => {
-  const viewSize = query.viewSize ? query.viewSize : process.env.VUE_APP_VIEW_SIZE;
+  const viewSize = query.viewSize || query.viewSize === 0 ? query.viewSize : process.env.VUE_APP_VIEW_SIZE;  
   const viewIndex = query.viewIndex ? query.viewIndex : 0;
 
   const payload = {

--- a/src/utils/solrHelper.ts
+++ b/src/utils/solrHelper.ts
@@ -7,8 +7,8 @@ const prepareOrderQuery = (query: any) => {
     "json": {
       "params": {
         "sort": `${query.sort}`,
-        "rows": viewSize,
-        "start": viewSize * viewIndex,
+        "rows": query.fetchFacets ? 0 : viewSize,
+        "start": query.fetchFacets ? 0 : (viewSize * viewIndex),
         "group": true,
         "group.field": `${query.groupBy}`,
         "group.limit": 10000,
@@ -87,6 +87,10 @@ const prepareOrderQuery = (query: any) => {
         }
       },
     }
+  }
+
+  if(query.fetchFacets) {
+    return payload;
   }
 
   if (query.queryString) {

--- a/src/utils/solrHelper.ts
+++ b/src/utils/solrHelper.ts
@@ -7,8 +7,8 @@ const prepareOrderQuery = (query: any) => {
     "json": {
       "params": {
         "sort": `${query.sort}`,
-        "rows": query.fetchFacets ? 0 : viewSize,
-        "start": query.fetchFacets ? 0 : (viewSize * viewIndex),
+        "rows": viewSize,
+        "start": viewSize * viewIndex,
         "group": true,
         "group.field": `${query.groupBy}`,
         "group.limit": 10000,

--- a/src/views/Transfers.vue
+++ b/src/views/Transfers.vue
@@ -365,7 +365,7 @@ const getShipmentMethodDesc = computed(() => store.getters["util/getShipmentMeth
 onIonViewWillEnter(async () => {
   await   store.dispatch("order/updateOrdersList", { orders: [], orderCount: 0, itemCount: 0 })
   isFetchingOrders.value = true;
-  await Promise.allSettled([store.dispatch('order/findOrders', { fetchFacets: true }), store.dispatch('util/fetchStatusDesc'), store.dispatch("util/fetchCarriersDetail"), store.dispatch("util/fetchShipmentMethodTypeDesc")])
+  await Promise.allSettled([store.dispatch('order/findOrders'), store.dispatch('order/fetchOrderFilters'), store.dispatch('util/fetchStatusDesc'), store.dispatch("util/fetchCarriersDetail"), store.dispatch("util/fetchShipmentMethodTypeDesc")])
   isFetchingOrders.value = false;
 })
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#49

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated logic to fetch the orders facets seperately form findOrders api

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)