### PR TITLE
Implemented:Added search bar functionality for searching facilities when creating new transfer Order (#67)

### DIFF
--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -9,12 +9,10 @@
       <ion-title>{{ translate("Select facility") }}</ion-title>
     </ion-toolbar>
   </ion-header>
-
   <ion-content>
     <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="$t('Search facilities')" v-model="queryString" @keyup.enter="queryString = $event.target.value; findFacility()" @keydown="preventSpecialCharacters($event)"/>
     <ion-radio-group v-model="selectedFacilityIdValue">
-      <ion-item
-        v-for="facility in facilities" :key="facility.facilityId">
+      <ion-item v-for="facility in facilities" :key="facility.facilityId">
           <ion-radio label-placement="end" justify="start" :value="facility.facilityId">
             <ion-label>
               {{ facility.facilityName ? facility.facilityName : facility.facilityId }}
@@ -26,31 +24,19 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button :disabled="selectedFacilityIdValue === selectedFacilityId" @click="saveFacility"><ion-icon :icon="saveOutline" /></ion-fab-button>
+    <ion-fab-button :disabled="selectedFacilityIdValue === selectedFacilityId" @click="saveFacility">
+      <ion-icon :icon="saveOutline" />
+    </ion-fab-button>
   </ion-fab>
 </template>
 
 <script setup lang="ts">
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonFab,
-  IonFabButton,
-  IonHeader,
-  IonIcon,
-  IonItem,
-  IonLabel,
-  IonRadio,
-  IonRadioGroup,
-  IonTitle,
-  IonToolbar,
-  modalController
-} from "@ionic/vue";
+import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonLabel, IonRadio,
+IonRadioGroup, IonTitle, IonToolbar, modalController } from "@ionic/vue";
 
 import { defineProps, onMounted, ref } from "vue";
 import { closeOutline, saveOutline } from "ionicons/icons";
-import { translate } from "@hotwax/dxp-components";
+import { translate } from '@hotwax/dxp-components';
 
 const props = defineProps(["selectedFacilityId", "facilities"]);
 
@@ -89,7 +75,7 @@ function closeModal(payload = {}) {
 }
 
 function saveFacility() {
-  closeModal({ selectedFacilityId: selectedFacilityIdValue.value });
+  closeModal({ selectedFacilityId: selectedFacilityIdValue.value })
 }
 </script>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#67

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Initially there was no functionality for searching facilities when we were creating new transfer order because in selectfacilityModel no SearchBar was present.Now SearchBar is available for Both Assgin and destination facility.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2025-05-30 20-31-37](https://github.com/user-attachments/assets/0af51bbd-fdb6-444f-8582-f0f58e41ceb5)
![Screenshot from 2025-05-30 20-32-16](https://github.com/user-attachments/assets/9c38afff-ae3f-4d8f-a434-c7e6e5073f9a)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)