### PR TITLE
fixed:displayed clear icon in qty input(#118)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -179,7 +179,7 @@
                 </ion-chip>
               </div>
               <ion-item>
-                <ion-input type="number" placeholder="Qty" v-model="item.quantity" />
+                <ion-input type="number" placeholder="Qty" v-model="item.quantity" :clear-input="true" />
               </ion-item>
               <div class="tablet">
                 <ion-checkbox v-model="item.isChecked" />


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#118 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed: Correctly showing the clear icon in qty input in create TO [page.]
<img width="1356" height="637" alt="Screenshot from 2025-10-14 20-20-12" src="https://github.com/user-attachments/assets/224ed49b-0712-4683-89ef-2ce6c7bf3dcd" />

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)