### PR TITLE
Fixed:showing the correct data(qoh) in createTo page after importing csv(#113)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -175,7 +175,7 @@
               <div class="tablet">
                 <ion-chip outline :color="isQOHAvailable(item) ? '' : 'warning'">
                   <ion-icon slot="start" :icon="sendOutline" />
-                  <ion-label>{{ item.qoh }} {{ translate("QOH") }}</ion-label>
+                  <ion-label>{{ item.qoh ?? '-' }} {{ translate("QOH") }}</ion-label>
                 </ion-chip>
               </div>
               <ion-item>
@@ -375,7 +375,7 @@ async function findProductFromIdentifier(payload: any) {
               sku: product.sku,
             quantity:quantityField ? Number(uploadedItemsByIdValue[idValue][quantityField]) || 0:0,
             isChecked: false,
-            qoh: stock?.qoh || 0,
+            qoh: stock?.qoh ?? null,
             atp: stock?.atp || 0
           })
         }


### PR DESCRIPTION

<img width="1356" height="637" alt="Screenshot from 2025-10-15 12-01-23" src="https://github.com/user-attachments/assets/f7cad4cd-2c5a-4353-8f14-c4a4df868c56" />
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#113

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed :fixes the Issue to show correct qoh data if not available showing '-' on Create Transfer Page after importing csv  .

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)