### PR TITLE
Improved: Added support to fetch order timeline after updating the order status (#98)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -357,9 +357,11 @@ async function updateOrderStatus(updatedStatusId: string) {
 
     if (!hasError(resp)) {
       showToast(translate("Order status updated successfully."))
-      await store.dispatch("order/fetchOrderDetails", props.orderId)
+      await Promise.all([
+        store.dispatch("order/fetchOrderDetails", props.orderId),
+        fetchOrderStatusHistoryTimeline()
+      ]);
       generateItemsListByParent();
-      fetchOrderStatusHistoryTimeline();
     } else {
       throw resp.data;
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#98 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Updates the order timeline when the order status changes.
* Handles cases where the status date-time from the API is null.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)