### PR TITLE
Improved: corrected the logic to find inbound shipment using package items for order item lookup(#138)

### DIFF
--- a/src/components/OrderItemDetailActionsPopover.vue
+++ b/src/components/OrderItemDetailActionsPopover.vue
@@ -8,7 +8,7 @@
       <ion-item button :disabled="!isEligibleToFulfill()" @click="redirectToFulfillItem()">
         {{ translate("Fulfill") }}
       </ion-item>
-      <ion-item button :disabled="!getCurrentItemInboundShipment()" @click="redirectToReceiveItem()">
+      <ion-item button :disabled="!isEligibleToReceive(item)" @click="redirectToReceiveItem()">
         {{ translate("Receive") }}
       </ion-item>
       <!--
@@ -102,8 +102,17 @@ function isEligibleToFulfill() {
   return !excludedStatuses.includes(currentOrder.value.statusId);
 }
 
-function getCurrentItemInboundShipment() {
-  return currentOrder.value.shipments?.find((shipment: any) => shipment.shipmentTypeId === "IN_TRANSFER" && shipment.packages?.some((pkg: any) => pkg.items?.some((item: any) => item.orderItemSeqId === props.item.orderItemSeqId)));
+function isEligibleToReceive(item: any) {
+  const order = currentOrder.value;
+
+  // Disable if order is created or has Fulfill-Only flow
+  if (order.statusId === "ORDER_CREATED" || order.statusFlowId === "TO_Fulfill_Only") return false;
+
+  // Disable if the item is completed
+  const orderItem = order.items?.find((orderItem: any) => orderItem.orderItemSeqId === item.orderItemSeqId);
+  if (orderItem?.statusId === "ITEM_COMPLETED") return false;
+
+  return true;
 }
 
 function redirectToFulfillItem() {
@@ -112,8 +121,7 @@ function redirectToFulfillItem() {
 }
 
 function redirectToReceiveItem() {
-  const shipment = getCurrentItemInboundShipment()
-  window.location.href = `${process.env.VUE_APP_RECEIVING_LOGIN_URL}?oms=${getOmsBaseUrl.value}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}&shipmentId=${shipment.shipmentId}&facilityId=${currentOrder.value.facilityId}&omsRedirectionUrl=${authStore.oms}`
+  window.location.href = `${process.env.VUE_APP_RECEIVING_LOGIN_URL}?oms=${getOmsBaseUrl.value}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}&orderId=${currentOrder.value.orderId}&facilityId=${currentOrder.value.facilityId}&omsRedirectionUrl=${authStore.oms}`
   popoverController.dismiss()
 }
 </script>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#138 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added logic to disable the **Receive** button when:
  - The order is in `ORDER_CREATED` status.
  - The order has `TO_Fulfill_Only` flow.
  - The item is in `ITEM_COMPLETED` state.
- Also updated the navigation link in the receiving app, replacing shipmentId with orderId so that users land on the Transfer Order detail page.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)