### PR TITLE
Fixed: When changing the origin facility and product store, if no item is present in the order, the loader will not appear on the screen(#150)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -433,7 +433,7 @@ async function productStoreUpdated() {
   if(isFacilityUpdated) {
     currentOrder.value.originFacilityId = facilities.value[0]?.facilityId;
     currentOrder.value.destinationFacilityId = "";
-    refetchAllItemsStock()
+    if(currentOrder.value.items.length) refetchAllItemsStock()
   }
   await store.dispatch("util/fetchStoreCarrierAndMethods", currentOrder.value.productStoreId);
   if(Object.keys(shipmentMethodsByCarrier.value)?.length) {
@@ -704,7 +704,7 @@ async function openSelectFacilityModal(facilityType: any) {
     if(result.data?.selectedFacilityId) {
       currentOrder.value[facilityType] = result.data.selectedFacilityId
       if(facilityType === "originFacilityId") {
-        refetchAllItemsStock()
+        if(currentOrder.value.items.length) refetchAllItemsStock()
       }
     }
   })


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#150 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check to skip fetching stock for items when changing the product store or origin facility if no items are present in the order.
- As a result, the ‘Updating items’ loader will no longer appear on the screen.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)