### PR TITLE
Improved: added eligibility checks for fulfill button based on order and item statuses (#132)

### DIFF
--- a/src/components/OrderItemDetailActionsPopover.vue
+++ b/src/components/OrderItemDetailActionsPopover.vue
@@ -99,13 +99,13 @@ async function editOrderedQuantity() {
 
 // Determines if a transfer order item is eligible for fulfillment
 function isEligibleToFulfill(item: any) {
-  const excludedOrderStatuses = ["ORDER_CREATED", "ORDER_CANCELLED", "ORDER_REJECTED"];
   const excludedItemStatuses = ["ITEM_PENDING_RECEIPT", "ITEM_COMPLETED"];
   const order = currentOrder.value;
 
-  // Check if the order has a CREATED, CANCELLED, REJECTED state or RECEIVE_ONLY flow
-  if (excludedOrderStatuses.includes(order.statusId) || order.statusFlowId === "TO_Receive_Only") return false;
-  // Check if the item has a PENDING_RECEIPT or COMPLETED status
+  // Disable if order is in CREATED state or has RECEIVE_ONLY flow
+  if (order.statusId === "ORDER_CREATED" || order.statusFlowId === "TO_Receive_Only") return false;
+
+  // Disable if the item is in PENDING_RECEIPT or COMPLETED state
   const orderItem = order.items?.find((orderItem: any) => orderItem.orderItemSeqId === item.orderItemSeqId);
   if (orderItem && excludedItemStatuses.includes(orderItem.statusId)) return false;
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#132 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added additional validation to control the visibility of the “Fulfill” button.
- Disabled fulfillment if the order is in ORDER_CREATED, ORDER_CANCELLED, ORDER_REJECTED, or has a RECEIVE_ONLY flow.
- Disabled fulfillment if the item is in ITEM_PENDING_RECEIPT or ITEM_COMPLETED status.
- Ensures users can only fulfill items that are valid for processing.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)