### PR TITLE
Fixed: added logic to show a user-friendly message from the API response when order approval fails (#175).

### DIFF
--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -21,6 +21,10 @@
         </ion-radio>
       </ion-item>
     </ion-radio-group>
+    <!-- Empty state -->
+    <div v-if="!facilities.length" class="empty-state">
+      <p>{{ translate("No facilities found") }}</p>
+    </div>
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
@@ -31,7 +35,7 @@
 </template>
   
 <script setup lang="ts">
-import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonLabel, IonRadio, IonRadioGroup, IonTitle, IonToolbar, modalController } from "@ionic/vue";
+import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonLabel, IonRadio, IonRadioGroup, IonSearchbar, IonTitle, IonToolbar, modalController } from "@ionic/vue";
 import { defineProps, onMounted, ref } from "vue";
 import { closeOutline, saveOutline } from "ionicons/icons";
 import { translate } from '@hotwax/dxp-components'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -65,6 +65,7 @@
   "Logout": "Logout",
   "Method": "Method",
   "Name": "Name",
+  "No facilities found": "No facilities found",
   "No item added to order": "No item added to order",
   "No new file upload. Please try again": "No new file upload. Please try again",
   "No order found": "No order found",

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -367,9 +367,11 @@ async function updateOrderStatus(updatedStatusId: string) {
     } else {
       throw resp.data;
     }
-  } catch(error) {
+  } catch(error: any) {
     logger.error(error)
-    showToast(translate("Failed to update order status."))
+    // Show the actual error message from API response
+    const errorMessage = error?.response?.data?.errors || translate("Failed to update order status.");
+    showToast(errorMessage)
     selectRef.value.$el.value = currentOrder.value
   }
 }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#175 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added logic to display a user-friendly message from the API response when order approval fails, improving clarity for the user.
- Also updated the Select Facility modal to display an empty state when no facilities are available.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)