### PR TITLE
Fixed:fixes the dismissal of alert from backdrop and reopening of alert after selecting from dropdown(#178)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -340,8 +340,9 @@ async function changeOrderStatus(updatedStatusId: string) {
     message: translate("Cancelation cannot be reverted. Are you sure you want to cancel this transfer order?"),
     buttons: [{
       text: translate("Dismiss"),
+      role: "cancel",
       handler: () => {
-        selectRef.value.$el.value = currentOrder.value
+        selectRef.value.$el.value = currentOrder.value.statusId;
       }
     }, {
       text: translate("Cancel"),
@@ -352,10 +353,6 @@ async function changeOrderStatus(updatedStatusId: string) {
   })
   alert.present()
 
-  const { role } = await alert.onDidDismiss();
-  if (role == 'backdrop') {
-      selectRef.value.$el.value = currentOrder.value.statusId
-  }
 }
 
 async function updateOrderStatus(updatedStatusId: string) {


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#178 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed:fixes the dismissal of alert from backdrop and reopening of alert after again selecting of cancel button. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)