### PR TITLE
Changed: Only cancel item in case last item left in the Order

### DIFF
--- a/src/components/OrderItemDetailActionsPopover.vue
+++ b/src/components/OrderItemDetailActionsPopover.vue
@@ -66,18 +66,11 @@ async function removeOrderItem() {
       text: translate("Confirm"),
       handler: async () => {
         try {
-          await OrderService.cancelOrderItem({
-            orderId: currentOrder.value.orderId,
-            orderItemSeqId: props.item.orderItemSeqId
-          })
+          await OrderService.cancelOrderItem(currentOrder.value.orderId, props.item.orderItemSeqId, false)
 
           const order = JSON.parse(JSON.stringify(currentOrder.value));
-          order.items.find((item: any) => {
-            if(item.orderItemSeqId === props.item.orderItemSeqId) {
-              item.statusId = "ITEM_CANCELLED"
-              return true;
-            }
-          })
+          const item = order.items.find((item: any) => item.orderItemSeqId === props.item.orderItemSeqId);
+          if (item) item.statusId = "ITEM_CANCELLED";
           store.dispatch("order/updateCurrent", order)
           popoverController.dismiss({ isItemUpdated: true });
           showToast(translate("Item removed successfully."));

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -212,11 +212,11 @@ const updateOrderItem = async (payload: any): Promise<any> => {
   });
 }
 
-const cancelOrderItem = async (payload: any): Promise<any> => {
+const cancelOrderItem = async (orderId: string, orderItemSeqId: string, cancelOrder: boolean): Promise<any> => {
   return api({
-    url: `oms/transferOrders/${payload.orderId}/items/${payload.orderItemSeqId}/status`,
+    url: `oms/transferOrders/${orderId}/items/${orderItemSeqId}/status`,
     method: "put",
-    data: { statusId: "ITEM_CANCELLED" }
+    data: { statusId: "ITEM_CANCELLED", checkCancelCompleteOrder: cancelOrder }
   })
 }
 


### PR DESCRIPTION
Changelog: Changed

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/transfers/issues/206

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Passed **checkCancelCompleteOrder** parameter as false in status change API to only cancel item if only once cacellable item is left.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/transfers#contribution-guideline)