### PR TITLE
Migrate deprecated OMS product-store calls to admin APIs

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -86,7 +86,7 @@ export const useProductStore = defineStore('productStore', {
 
       try {
         const resp = await api({
-          url: `/oms/productStores/${productStoreId}/facilities`,
+          url: `/admin/productStores/${productStoreId}/facilities`,
           method: "get",
           params: {
             productStoreId,
@@ -114,7 +114,7 @@ export const useProductStore = defineStore('productStore', {
     },
     async fetchProductStoreDetails(payload: any): Promise<any> {
       return api({
-        url: `/oms/productStores/${payload.productStoreId}`,
+        url: `/admin/productStores/${payload.productStoreId}`,
         method: "GET"
       });
     },
@@ -171,7 +171,7 @@ export const useProductStore = defineStore('productStore', {
         }
 
         const resp = await api({
-          url: `/oms/productStores`,
+          url: `/admin/productStores`,
           method: "GET",
           params: payload
         });


### PR DESCRIPTION
Refs hotwax/oms#529.

Targets `transfers-refactored`. Migrates transfers product-store calls from deprecated `/oms/productStores` resources to `/admin/productStores` replacements. Response handling was reviewed and remains unchanged.