### PR TITLE
Mount Fast Travel in Transfers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,15 @@ VITE_FULFILLMENT_LOGIN_URL="https://fulfillment-dev.hotwax.io/login"
 VITE_RECEIVING_LOGIN_URL="https://receiving-dev.hotwax.io/login"
 VITE_MAPPING_FIELDS='{"externalOrderId":{"label":"External Order ID","description":"The unique identifier for the order in the external system","required":true},"originFacilityId":{"label":"Origin Facility ID","description":"The facility ID from which items will be transferred","required":true},"destinationFacilityId":{"label":"Destination Facility ID","description":"The facility ID where items will be received","required":true},"sku":{"label":"SKU","description":"The product SKU","required":true},"quantity":{"label":"Quantity","description":"The quantity to transfer","required":true},"orderName":{"label":"Order Name","description":"Name of the transfer order","required":false},"productStoreId":{"label":"Product Store ID","description":"The product store ID (defaults to current store if empty)","required":false},"carrierPartyId":{"label":"Carrier Party ID","description":"The carrier party ID","required":false},"shipmentMethodTypeId":{"label":"Shipment Method Type ID","description":"The shipment method type ID","required":false},"statusFlowId":{"label":"Status Flow ID","description":"The order lifecycle status flow","required":false},"shipDate":{"label":"Ship Date","description":"The estimated ship date (YYYY-MM-DD)","required":false},"deliveryDate":{"label":"Delivery Date","description":"The estimated delivery date (YYYY-MM-DD)","required":false}}'
 VITE_DEFAULT_PRODUCT_STORE_SETTINGS={"PRDT_IDEN_PREF":{"stateKey":"productIdentifier.productIdentificationPref","value":{"primaryId":"SKU","secondaryId":"productId"}}}
+
+# --- Fast Travel (Cmd/Ctrl+K app switcher) ---
+# Base URLs of sibling HotWax admin apps (VITE_LOGIN_URL above remains the auth/login URL).
+# Blank = that app shows as "Not configured" in the palette for this deployment.
+VITE_LAUNCHPAD_URL=""
+VITE_JOB_MANAGER_URL=""
+VITE_ORDER_MANAGER_URL=""
+VITE_ORDER_ROUTING_URL=""
+VITE_COMPANY_URL=""
+VITE_PRODUCTS_URL=""
+VITE_TRANSFERS_URL=""
+VITE_CYCLE_COUNT_URL=""

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,14 @@
 <template>
   <ion-app data-testid="app-root">
     <ion-router-outlet data-testid="app-router-outlet" />
+    <FastTravel current-app="transfers" />
   </ion-app>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeMount, onMounted, onUnmounted, ref } from "vue";
 import { IonApp, IonRouterOutlet, loadingController } from "@ionic/vue";
-import { emitter, logger, translate } from "@common"
+import { emitter, FastTravel, logger, translate } from "@common"
 import { Settings } from 'luxon'
 import { useAuth } from "@common/composables/useAuth";
 import { useUserStore } from "@/store/user";


### PR DESCRIPTION
## Business summary
Adds the shared AccxUI Fast Travel entry point to Transfers so operators can use Cmd/Ctrl+K to move between configured HotWax admin apps from the app shell.

Closes #239

## Scope
- Mounts the shared `FastTravel` component in the refactored Transfers app shell with `transfers` as the current app id.
- Documents sibling app URL variables in `.env.example` so deployments can enable the destinations they support.
- Keeps unconfigured destinations disabled through the shared registry behavior.

## Verification
- `./node_modules/.bin/vite build` passed in a clean PR worktree.
- Build verification used AccxUI shared `common` resolution plus temporary local symlinks for the wrapper `tsconfig.json` and the existing `vue-virtual-scroller` dependency, then removed those temporary symlinks.