### PR TITLE
Improved: Centralized app permissions into a single authorization actions file and removed unused casl and boon-js dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@capacitor/android": "catalog:",
     "@capacitor/core": "catalog:",
-    "@casl/ability": "^6.0.0",
     "@ionic/core": "catalog:",
     "@ionic/vue": "catalog:",
     "@ionic/vue-router": "catalog:",

--- a/src/authorization/actions.ts
+++ b/src/authorization/actions.ts
@@ -1,0 +1,16 @@
+/**
+ * App actions mapped to the server permissions they require.
+ *
+ * Views, components and routes should always refer to an action from this file instead of
+ * hardcoding a server permission, so that a permission change is a one line change here.
+ *
+ * The value is the permission expression evaluated by `hasPermission` of the user store.
+ * It supports the `OR` and `AND` operators, and an empty value means the action is allowed
+ * for every logged in user.
+ */
+export default {
+  APP_BULK_UPLOAD: "TRANSFERS_BULK_CREATE",
+  APP_DISCREPANCY_REPORT: "TRANSFERS_DISCREPANCY_VIEW",
+  APP_PRODUCT_IDENTIFIER_UPDATE: "STOREFULFILLMENT_ADMIN",
+  APP_PWA_STANDALONE_ACCESS: "COMMON_ADMIN"
+} as const satisfies Record<string, string>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -11,12 +11,12 @@
       {{ 'Choosing a product identifier allows you to view products with your preferred identifiers.' }}
     </ion-card-content>
 
-    <ion-item :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN')">
+    <ion-item :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Primary')" interface="popover" :placeholder="'primary identifier'" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
       </ion-select>
     </ion-item>
-    <ion-item lines="none" :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN')">
+    <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Secondary')" interface="popover" :placeholder="'secondary identifier'" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
         <ion-select-option value="">{{ "None" }}</ion-select-option>
@@ -49,6 +49,7 @@ import { useUserStore } from '@/store/user'
 import { computed, onMounted } from 'vue';
 import { commonUtil, DxpShopifyImg, translate } from "@common";
 import { shuffleOutline } from "ionicons/icons";
+import Actions from "@/authorization/actions";
 
 const productStore = useProductStore();
 const userStore = useUserStore()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,6 +8,7 @@ import CreateOrder from "@/views/CreateOrder.vue";
 import BulkUpload from "@/views/BulkUpload.vue";
 import Login from "@common/components/Login.vue";
 import { useUserStore } from "@/store/user";
+import Actions from "@/authorization/actions";
 declare module 'vue-router' {
   interface RouteMeta {
     permissionId?: string;
@@ -46,7 +47,7 @@ const routes: Array<RouteRecordRaw> = [
         name: "Discrepancies",
         component: () => import("@/views/Discrepancies.vue"),
         meta: {
-          permissionId: "TRANSFERS_DISCREPANCY_VIEW"
+          permissionId: Actions.APP_DISCREPANCY_REPORT
         }
       },
       {
@@ -69,7 +70,7 @@ const routes: Array<RouteRecordRaw> = [
     component: BulkUpload,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "TRANSFERS_BULK_CREATE"
+      permissionId: Actions.APP_BULK_UPLOAD
     }
   },
   {

--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -4,7 +4,7 @@
       <ion-toolbar>
         <ion-back-button data-testid="create-order-back-btn" slot="start" :default-href="`/tabs/transfers`" />
         <ion-title>{{ translate("Create transfer order") }}</ion-title>
-        <ion-buttons slot="end" v-if="userStore.hasPermission('TRANSFERS_BULK_CREATE')">
+        <ion-buttons slot="end" v-if="userStore.hasPermission(Actions.APP_BULK_UPLOAD)">
           <ion-button data-testid="create-order-bulk-upload-btn" @click="router.push('/bulk-upload')">{{ translate("Bulk upload") }}</ion-button>
         </ion-buttons>
       </ion-toolbar>
@@ -212,6 +212,7 @@ import { useProductStore as useProduct } from "@/store/product";
 import { useProductStore } from "@/store/productStore";
 import { useUserStore as useAppUserStore } from "@/store/user";
 import { useUtilStore } from "@/store/util";
+import Actions from "@/authorization/actions";
 
 const orderStore = useOrderStore();
 const product = useProduct();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -22,7 +22,7 @@
             </ion-card-header>
           </ion-item>
           <ion-button data-testid="settings-logout-btn" color="danger" @click="logout()">{{ translate("Logout") }}</ion-button>
-          <ion-button data-testid="settings-go-launchpad-btn" :standalone-hidden="!userStore.hasPermission('COMMON_ADMIN')" fill="outline" @click="goToLaunchpad()">
+          <ion-button data-testid="settings-go-launchpad-btn" :standalone-hidden="!userStore.hasPermission(Actions.APP_PWA_STANDALONE_ACCESS)" fill="outline" @click="goToLaunchpad()">
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
@@ -66,6 +66,7 @@ import DxpOmsInstanceNavigator from "@/components/DxpOmsInstanceNavigator.vue";
 import DxpTimeZoneSwitcher from "@/components/DxpTimeZoneSwitcher.vue";
 import { logger, translate } from "@common";
 import { useAuth } from "@common/composables/useAuth";
+import Actions from "@/authorization/actions";
 
 
 

--- a/src/views/Tabs.vue
+++ b/src/views/Tabs.vue
@@ -7,7 +7,7 @@
           <ion-icon :icon="businessOutline" />
           <ion-label data-testid="tabs-transfers-btn">{{ translate("Transfers") }}</ion-label>
         </ion-tab-button>
-        <ion-tab-button v-if="userStore.hasPermission('TRANSFERS_DISCREPANCY_VIEW')" tab="discrepancies" href="/tabs/discrepancies">
+        <ion-tab-button v-if="userStore.hasPermission(Actions.APP_DISCREPANCY_REPORT)" tab="discrepancies" href="/tabs/discrepancies">
           <ion-icon :icon="alertCircleOutline" />
           <ion-label data-testid="tabs-discrepancies-btn">{{ translate("Discrepancies") }}</ion-label>
         </ion-tab-button>
@@ -26,6 +26,7 @@ import { alertCircleOutline, businessOutline, settingsOutline } from "ionicons/i
 import router from "../router";
 import { translate } from "@common";
 import { useUserStore } from "@/store/user";
+import Actions from "@/authorization/actions";
 
 const userStore = useUserStore();
 


### PR DESCRIPTION
Introduces `src/authorization/actions.ts`, a single map of app action to the server permission it requires. Views, components and routes now pass an action instead of a hardcoded permission string, so a permission change is a one line change in that file.

Action names are taken from the pre-migration `src/authorization/Rules.ts` wherever a rule matched, so they stay familiar. The value is the permission expression itself, so the user store's `hasPermission` is unchanged.

Also drops `@casl/ability` / `boon-js` from `package.json` — leftovers from the pre-accxui authorization layer that are no longer imported anywhere.

No behaviour change: every call site resolves to the exact same permission expression as before.

> Note: the matching `pnpm-lock.yaml` update lives in the accxui repo and is not part of this PR.