### PR TITLE
Fix: Support configured product identifiers in Create Transfer Order search (#112)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -116,7 +116,7 @@
           <div class="item-search">
             <ion-item>
               <ion-icon slot="start" :icon="listOutline"/>
-              <ion-input data-testid="create-order-add-product-input" :label="translate('Add product')" label-placement="floating" :clear-input="true" v-model="queryString" :placeholder="translate('Searching on SKU')" @keyup.enter="addProductToCount()" />
+              <ion-input data-testid="create-order-add-product-input" :label="translate('Add product')" label-placement="floating" :clear-input="true" v-model="queryString" :placeholder="productSearchPlaceholder" @keyup.enter="addProductToCount()" />
             </ion-item>
             <ion-item lines="none" v-if="isSearchingProduct">
               <ion-spinner color="secondary" name="crescent"></ion-spinner>
@@ -273,6 +273,15 @@ const getProduct = computed(() => product.getProduct)
 const shipmentMethodsByCarrier = computed(() => utilStore.getShipmentMethodsByCarrier)
 const getCarrierDesc = computed(() => utilStore.getCarrierDesc)
 const facilities = computed(() => productStore.getProductStoreFacilities)
+
+const productSearchPlaceholder = computed(() => {
+  const primaryId = productStore.getProductIdentificationPref?.primaryId;
+  const options = productStore.getProductIdentificationOptions || [];
+  const description = options.find((option: any) => option.goodIdentificationTypeId === primaryId)?.description;
+
+  return translate(`Searching on ${description || primaryId}`);
+});
+
 // Implemented watcher to display the search spinner correctly. Mainly the watcher is needed to not make the findProduct call always and to create the debounce effect.
 // Previously we were using the `debounce` property of ion-input but it was updating the searchedString and making other related effects after the debounce effect thus the spinner is also displayed after the debounce
 // effect is completed.
@@ -300,6 +309,7 @@ watch(queryString, (value) => {
 onIonViewDidEnter(async () => {
   emitter.emit("presentLoader")
   stores.value = useProductStore().productStores
+  productStore.prepareProductIdentifierOptions();
   const currentProductStoreId = (useProductStore().getCurrentProductStore as any)?.productStoreId || "";
   currentOrder.value.productStoreId = currentProductStoreId
   await Promise.allSettled([utilStore.fetchStoreCarrierAndMethods(currentProductStoreId), utilStore.fetchCarriersDetail()])
@@ -616,10 +626,10 @@ async function findProduct() {
   isSearchingProduct.value = true;
   try {
     const resp = await useSolrSearch().searchProducts({
+      "keyword": queryString.value.trim(),
       "filters": {
         "isVirtual": { value: "false" },
-        "isVariant": { value: "true" },
-        "sku": { value: `*${queryString.value}*` }
+        "isVariant": { value: "true" }
       },
       "viewSize": 1
     })


### PR DESCRIPTION
## Related Issue

Closes #112

## Summary

Updates the Create Transfer Order product search to respect the Product Search Configuration instead of relying on a hardcoded SKU search.

## Changes Made

- Replaced the static search placeholder (`Searching on SKU`) with a reactive placeholder derived from the user's configured primary product identifier.
- Updated `findProduct()` to use the shared Solr keyword search instead of a hardcoded SKU filter, allowing product searches to respect the configured Product Search Configuration.
- Initialized product identifier options in `onIonViewDidEnter()` to ensure the placeholder displays the correct identifier when the page loads.

## Verification

- Changed the primary product identifier in **Settings → Product Search Configuration** (e.g., Product Name, Barcode, SKU).
- Verified the search placeholder updates based on the configured primary product identifier.
- Verified products can be searched using the configured product identifier.
- Verified the existing Create Transfer Order workflow continues to function as expected.