### PR TITLE
Fix: Refresh facilities when product store changes in create transfer flow (#264)

### DIFF
--- a/src/views/CreateOrder.vue
+++ b/src/views/CreateOrder.vue
@@ -348,14 +348,23 @@ async function addProductToCount() {
 }
 
 async function productStoreUpdated() {
+  // Reset selected facilities
+  currentOrder.value.originFacilityId = "";
+  currentOrder.value.destinationFacilityId = "";
 
-  const isFacilityUpdated = currentOrder.value.originFacilityId !== facilities.value[0]?.facilityId
-  if(isFacilityUpdated) {
-    currentOrder.value.originFacilityId = "";
-    currentOrder.value.destinationFacilityId = "";
-    if(currentOrder.value.items.length) refetchAllItemsStock()
+  // Refresh facilities for the newly selected Product Store
+  if (currentOrder.value.productStoreId) {
+    await productStore.fetchProductStoreFacilities(currentOrder.value.productStoreId);
   }
+
+  // Refetch stock if items already exist
+  if (currentOrder.value.items.length) {
+    refetchAllItemsStock();
+  }
+
+  // Refresh carrier and shipment methods
   await utilStore.fetchStoreCarrierAndMethods(currentOrder.value.productStoreId);
+
   if(Object.keys(shipmentMethodsByCarrier.value)?.length) {
     currentOrder.value.carrierPartyId = Object.keys(shipmentMethodsByCarrier.value)[0]
     selectUpdatedMethod()


### PR DESCRIPTION
### Related Issue

Closes #264

### Summary

Fixes an issue in the Create Transfer Order flow where changing the selected Product Store continued showing facilities from the previously selected store in the facility selection modal.

### Changes

- Updated `productStoreUpdated()` in `CreateOrder.vue` to fetch facilities for the newly selected Product Store using `productStore.fetchProductStoreFacilities(...)`.
- Reset the selected Origin and Destination facilities when the Product Store changes.
- Preserved the existing stock refresh behavior by refetching item stock when items are already present.

### Testing

1. Open the **Create Transfer Order** page.
2. Verify the Origin and Destination facilities for the initially selected Product Store.
3. Change the **Product Store**.
4. Open the Origin or Destination facility selection modal.
5. Verify that:
   - The selected Origin and Destination facilities are cleared.
   - Only facilities associated with the newly selected Product Store are displayed.